### PR TITLE
fix: fixed IOR exception in CreateObjectConverter window

### DIFF
--- a/Assets/Plugins/Bayat/Json/Editor/CreateObjectConverterWindow.cs
+++ b/Assets/Plugins/Bayat/Json/Editor/CreateObjectConverterWindow.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
@@ -308,7 +308,7 @@ namespace Bayat.Json
             this.typesPageCount = (this.typesCount + TypesPerPage - 1) / TypesPerPage;
             this.typesOffsetIndex = this.typesPageIndex * TypesPerPage;
 
-            for (int i = this.typesOffsetIndex; i - this.typesOffsetIndex < TypesPerPage; i++)
+            for (int i = this.typesOffsetIndex; i - this.typesOffsetIndex < TypesPerPage && i >= 0; i++)
             {
                 if (i < this.typeNames.Length)
                 {
@@ -359,7 +359,7 @@ namespace Bayat.Json
             {
                 this.typesPageIndex = 0;
             }
-            else if (this.typesPageIndex >= this.typesPageCount)
+            else if (this.typesPageIndex >= this.typesPageCount && typesPageCount > 0)
             {
                 this.typesPageIndex = this.typesPageCount - 1;
             }


### PR DESCRIPTION
When searching for types inside "CreateObjectConverter" window, in case there is 0 pages (e.g. user makes typo) - `IndexOutOf Range` exc been throwed and window shuts dead. This happend because of `typesPageIndex` field being assigned with `typesPageCount  - 1` value. So, when there is 0 pages - we are getting -1 index.  I added 0 check, and just in case - extra 0 check inside `for` cycle.