### PR TITLE
Add Asset Reference Resolving by labels. Add including only ignored tags/labels. Update AssetRefResolver custom editor.

### DIFF
--- a/Assets/Plugins/Bayat/Core/Editor/AssetReferenceResolverEditor.cs
+++ b/Assets/Plugins/Bayat/Core/Editor/AssetReferenceResolverEditor.cs
@@ -1,7 +1,5 @@
-﻿using Bayat.Core.EditorWindows;
-
+using Bayat.Core.EditorWindows;
 using UnityEditor;
-
 using UnityEngine;
 
 namespace Bayat.Core
@@ -15,6 +13,9 @@ namespace Bayat.Core
         protected SerializedProperty mode;
         protected SerializedProperty refreshDependenciesTimeoutInSeconds;
         protected SerializedProperty ignoredTags;
+        protected SerializedProperty includeIgnoredTags;
+        protected SerializedProperty ignoredLabels;
+        protected SerializedProperty includeIgnoredLabels;
         protected SerializedProperty ignoreStatic;
         protected bool foldout = false;
 
@@ -24,6 +25,9 @@ namespace Bayat.Core
             this.mode = serializedObject.FindProperty("mode");
             this.refreshDependenciesTimeoutInSeconds = serializedObject.FindProperty("refreshDependenciesTimeoutInSeconds");
             this.ignoredTags = serializedObject.FindProperty("ignoredTags");
+            this.includeIgnoredTags = serializedObject.FindProperty("includeIgnoredTags");
+            this.ignoredLabels = serializedObject.FindProperty("ignoredLabels");
+            this.includeIgnoredLabels = serializedObject.FindProperty("includeIgnoredLabels");
             this.ignoreStatic = serializedObject.FindProperty("ignoreStatic");
         }
 
@@ -40,6 +44,9 @@ namespace Bayat.Core
             EditorGUILayout.Space();
             EditorGUILayout.PropertyField(this.mode);
             EditorGUILayout.PropertyField(this.ignoredTags);
+            EditorGUILayout.PropertyField(this.includeIgnoredTags);
+            EditorGUILayout.PropertyField(this.ignoredLabels);
+            EditorGUILayout.PropertyField(this.includeIgnoredLabels);
             EditorGUILayout.PropertyField(this.ignoreStatic);
 
             EditorGUI.BeginDisabledGroup(this.assetReferenceResolver.Mode == ReferenceResolverMode.Manual);

--- a/Assets/Plugins/Bayat/Core/Runtime/AssetReferenceResolver.cs
+++ b/Assets/Plugins/Bayat/Core/Runtime/AssetReferenceResolver.cs
@@ -675,7 +675,7 @@ namespace Bayat.Core
         /// </summary>
         /// <param name="gameObject">The GameObject to check</param>
         /// <returns>Returns true if the GameObject has any invalid tag, otherwise false.
-        /// In case <see cref="includeIgnoredTags"/> is true, returns true when GameObject has "invalid" label and vise versa.</returns>
+        /// In case <see cref="includeIgnoredTags"/> is true, returns false when GameObject has "invalid" label and vise versa.</returns>
         public virtual bool HasInvalidTag(GameObject gameObject)
         {
             for (int i = 0; i < this.ignoredTags.Length; i++)
@@ -695,7 +695,7 @@ namespace Bayat.Core
         /// </summary>
         /// <param name="unityObject">The Asset to check</param>
         /// <returns>Returns true if the Asset has any invalid labels, otherwise false. 
-        /// In case <see cref="includeIgnoredLabels"/> is true, returns true when Asset has "invalid" label and vise versa.</returns>
+        /// In case <see cref="includeIgnoredLabels"/> is true, returns false when Asset has "invalid" label and vise versa.</returns>
         public bool HasInvalidLabel(UnityObject unityObject)
         {
             if (ignoredLabels.Length < 1) return false;

--- a/Assets/Plugins/Bayat/Core/Runtime/AssetReferenceResolver.cs
+++ b/Assets/Plugins/Bayat/Core/Runtime/AssetReferenceResolver.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -15,6 +15,7 @@ using UnityEditor.SceneManagement;
 using Bayat.Core.Utilities;
 
 using UnityObject = UnityEngine.Object;
+using System.Threading;
 
 namespace Bayat.Core
 {
@@ -78,6 +79,19 @@ namespace Bayat.Core
         [Tooltip("Ignore GameObjects that have any of these tags")]
         [SerializeField]
         protected string[] ignoredTags = new string[] { "EditorOnly" };
+
+        [Tooltip("Include GameObjects that have any of these tags, ignore the others.")]
+        [SerializeField]
+        protected bool includeIgnoredTags = false;
+
+        [Tooltip("Ignore Assets that have any of these labels (bottom right icon in the asset inspector)")]
+        [SerializeField]
+        protected string[] ignoredLabels = new string[0];
+
+        [Tooltip("Include Assets that have any of these labels, ignore the others.")]
+        [SerializeField]
+        protected bool includeIgnoredLabels = false;
+
         [Tooltip("Whether to ignore static GameObjects")]
         [SerializeField]
         protected bool ignoreStatic = false;
@@ -630,6 +644,9 @@ namespace Bayat.Core
                     return false;
                 }
             }
+
+            if (HasInvalidLabel(unityObject)) return false;            
+
             GameObject gameObject = null;
             if (unityObject is GameObject)
             {
@@ -657,18 +674,36 @@ namespace Bayat.Core
         /// Checks whether the given GameObject has any invalid tags determined using <see cref="ignoredTags"/> field.
         /// </summary>
         /// <param name="gameObject">The GameObject to check</param>
-        /// <returns>Returns true if the GameObject has any invalid tag, otherwise false</returns>
+        /// <returns>Returns true if the GameObject has any invalid tag, otherwise false.
+        /// In case <see cref="includeIgnoredTags"/> is true, returns true when GameObject has "invalid" label and vise versa.</returns>
         public virtual bool HasInvalidTag(GameObject gameObject)
         {
             for (int i = 0; i < this.ignoredTags.Length; i++)
             {
                 if (gameObject.CompareTag(this.ignoredTags[i]))
                 {
-                    return true;
+                    return !includeIgnoredTags;
                 }
             }
-            return false;
+            return includeIgnoredTags;
         }
+
+
+        /// <summary>
+        /// Checks whether the given Asset has any invalid labels (they're located at the bottom of the asset's inspector view) inspector view),
+        /// determined using <see cref="ignoredLabels"/> field.
+        /// </summary>
+        /// <param name="unityObject">The Asset to check</param>
+        /// <returns>Returns true if the Asset has any invalid labels, otherwise false. 
+        /// In case <see cref="includeIgnoredLabels"/> is true, returns true when Asset has "invalid" label and vise versa.</returns>
+        public bool HasInvalidLabel(UnityObject unityObject)
+        {
+            if (ignoredLabels.Length < 1) return false;
+
+            var objLabels = AssetDatabase.GetLabels(unityObject);
+            return objLabels.Any(label => ignoredLabels.Contains(label, StringComparer.InvariantCultureIgnoreCase)) ^ includeIgnoredLabels;
+        }
+
 
         [InitializeOnLoadMethod]
         public static void UpdateLocation()


### PR DESCRIPTION
Currently AssetReferenceResolver use "Ignore by GO tag" logic. It works fine for prefab assets, but there are thousands of non-GO  assets, which may need to be ignored. Unity has powerful feature for filtering assets - labels, which can be assigned in the bottom section of asset inspector. So i added `ignoredLabels` string[] field and implemented filtering logic.

Also, in some cases user may want to **include** only assets with certain tag/label, instead of **ignoring** those labels/tags. For this case i added 2 fields `includeIgnoredTags/Labels`

I tested it for my project, works fine. Of course there will be extra CPU/Memory extra utilization (about 15%), but only when user adds any values to `ignoredLabels`. IncludeIgnored works via simple XOR and boolean ops.

I'm also suggesting to remove "Tags" logic for reference resolving, and maybe add labels to PrefabReferenceResolver, because labels are the perfect way for asset filtering during EditorTime (where reference resolving is actually happening), also, unlike tags, we can apply any amount of labels to the asset/prefab. But this suggestions are completely under your command, just let me know if you accept it.